### PR TITLE
HTTPS + Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/diasdavid/go-ipfs-dep",
   "devDependencies": {
     "aegir": "^8.1.2",
+    "rimraf": "^2.5.4",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ module.exports = function (callback) {
 
   const fileExtension = isWindows ? '.zip' : '.tar.gz'
   const fileName = 'ipfs_v' + version + '_' + goenv.GOOS + '-' + goenv.GOARCH + fileExtension
-  const url = 'http://dist.ipfs.io/go-ipfs/v' + version + '/go-' + fileName
+  const url = 'https://dist.ipfs.io/go-ipfs/v' + version + '/go-' + fileName
   const installPath = path.resolve(__dirname, '..')
   const fileStream = request.get(url)
 

--- a/test/index.js
+++ b/test/index.js
@@ -3,13 +3,16 @@
 var test = require('tape')
 var fs = require('fs')
 var path = require('path')
+var rimraf = require('rimraf')
 
 var download = require('../src')
 
 test('Ensure ipfs gets downloaded', function (t) {
   t.plan(2)
+  const dir = path.resolve(__dirname, '../go-ipfs')
+  rimraf.sync(dir)
   download(function () {
-    fs.stat(path.resolve(__dirname, '../go-ipfs'), function (err, stats) {
+    fs.stat(dir, function (err, stats) {
       t.error(err, 'ipfs bin should stat without error')
       t.ok(stats, 'ipfs was downloaded')
     })


### PR DESCRIPTION
Hello, thanks for all your work on IPFS.  Really cool project!

This PR makes the download run over HTTPS (important when downloading binaries!!!).  It also improves the test by removing the `go-ipfs` directory before the test starts.  Before, the directory was preserved between runs, which could have resulted in false positives.